### PR TITLE
Add callback/delegate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Ctypes
 
+## v0.2.0 - TBD
+
++ Add support for defining C callback/delegate functions using a PowerShell scriptblock
+
 ## v0.1.0 - 2023-01-23
 
 + Initial version of the `Ctypes` module

--- a/module/Ctypes.psd1
+++ b/module/Ctypes.psd1
@@ -19,7 +19,7 @@
     }
 
     # Version number of this module.
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/AstParser.cs
+++ b/src/AstParser.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+
+namespace Ctypes;
+
+internal sealed class AstParser
+{
+    public static FieldOffsetAttribute ParseFieldOffset(AttributeAst attr)
+    {
+        if (attr.PositionalArguments.Count != 1)
+        {
+            throw new ArgumentException(
+                $"Expecting 1 argument for FieldOffset attribute but found {attr.PositionalArguments.Count}");
+        }
+
+        FieldOffsetAttribute fieldOffset = new(GetAttributeIntValue(attr.PositionalArguments[0], "FieldOffset"));
+        return fieldOffset;
+    }
+
+    public static MarshalAsAttribute ParseMarshalAs(AttributeAst attr)
+    {
+        if (attr.PositionalArguments.Count != 1)
+        {
+            throw new ArgumentException(
+                $"Expecting 1 argument for MarshalAs attribute but found {attr.PositionalArguments.Count}");
+        }
+
+        MarshalAsAttribute? marshalAs = null;
+        if (TryGetAttributeValue(attr.PositionalArguments[0], out var intMarshalAs, out var stringMarshalAs))
+        {
+            if (stringMarshalAs != null && Enum.TryParse<UnmanagedType>(stringMarshalAs, out var unmanagedType))
+            {
+                marshalAs = new(unmanagedType);
+            }
+            else if (intMarshalAs != null && intMarshalAs < short.MaxValue)
+            {
+                marshalAs = new((short)intMarshalAs);
+            }
+        }
+
+        if (marshalAs == null)
+        {
+            throw new ArgumentException($"Failed to extract MarshalAs UnmanagedType value for {attr.ToString()}");
+        }
+
+        foreach (NamedAttributeArgumentAst arg in attr.NamedArguments)
+        {
+            switch (arg.ArgumentName.ToLowerInvariant())
+            {
+                case "arraysubtype":
+                    marshalAs.ArraySubType = GetAttributeEnumValue<UnmanagedType>(arg.Argument, "ArraySubType");
+                    break;
+
+                case "sizeconst":
+                    marshalAs.SizeConst = GetAttributeIntValue(arg.Argument, "SizeConst");
+                    break;
+
+                default:
+                    throw new ArgumentException(
+                        $"Unsupported MarshalAs named argument '{arg.ArgumentName}', expecting ArraySubType or SizeConst");
+            }
+        }
+
+        return marshalAs;
+    }
+
+    private static int GetAttributeIntValue(ExpressionAst ast, string attributeName)
+    {
+        if (TryGetAttributeValue(ast, out var intValue, out var _) && intValue != null)
+        {
+            return (int)intValue;
+        }
+
+        throw new ArgumentException($"Failed to extract expected int value for {attributeName}");
+    }
+
+    private static T GetAttributeEnumValue<T>(ExpressionAst ast, string attributeName)
+        where T : struct
+    {
+        if (TryGetAttributeValue(ast, out var intValue, out var strValue))
+        {
+            if (intValue != null)
+            {
+                return (T)(object)intValue;
+            }
+
+            if (strValue != null && Enum.TryParse<T>(strValue, true, out var enumValue))
+            {
+                return enumValue;
+            }
+        }
+
+        Type enumType = typeof(T);
+        throw new ArgumentException($"Failed to extract expected enum {enumType.Name} value for {attributeName}");
+    }
+
+    private static bool TryGetAttributeValue(ExpressionAst ast, out int? intValue, out string? stringValue)
+    {
+        intValue = null;
+        stringValue = null;
+        if (ast is StringConstantExpressionAst stringExp)
+        {
+            stringValue = stringExp.Value;
+            return true;
+        }
+        else if (ast is ConstantExpressionAst constExp)
+        {
+            bool res = int.TryParse(constExp.Value.ToString(), out var extractedInt);
+            intValue = extractedInt;
+            return res;
+        }
+        else if (ast is MemberExpressionAst memberExp && memberExp.Member is StringConstantExpressionAst memberValue)
+        {
+            stringValue = memberValue.Value;
+            return true;
+        }
+
+        return false;
+    }
+}
+
+internal sealed class TypeInformation
+{
+    public string Name { get; }
+    public Type Type { get; }
+    public bool IsIn { get; }
+    public bool IsOut { get; }
+    public MarshalAsAttribute? MarshalAs { get; }
+    public FieldOffsetAttribute? FieldOffset { get; }
+    public ScriptBlockDelegate? DelegateInfo { get; }
+
+    public TypeInformation(string name, Type type, MarshalAsAttribute? marshalAs = null,
+        FieldOffsetAttribute? fieldOffset = null, bool isIn = false, bool isOut = false,
+        ScriptBlockDelegate? delegateInfo = null)
+    {
+        Type = type;
+        Name = name;
+        MarshalAs = marshalAs;
+        FieldOffset = fieldOffset;
+        IsIn = isIn;
+        IsOut = isOut;
+        DelegateInfo = delegateInfo;
+    }
+
+    public CustomAttributeBuilder? CreateMarshalAsAttribute()
+    {
+        if (MarshalAs == null)
+        {
+            return null;
+        }
+
+        List<FieldInfo> fields = new();
+        List<object> values = new();
+
+        if (MarshalAs.SizeConst != 0)
+        {
+            fields.Add(ReflectionInfo.MarshalAsSizeConstField);
+            values.Add(MarshalAs.SizeConst);
+        }
+
+        if (MarshalAs.ArraySubType != 0)
+        {
+            fields.Add(ReflectionInfo.MarshalAsArraySubTypeField);
+            values.Add(MarshalAs.ArraySubType);
+        }
+
+        return new(
+            ReflectionInfo.MarshalAsCtor,
+            new object[] { MarshalAs.Value },
+            fields.ToArray(),
+            values.ToArray()
+        );
+    }
+
+    public CustomAttributeBuilder? CreateFieldOffsetAttribute()
+    {
+        if (FieldOffset == null)
+        {
+            return null;
+        }
+
+        return new(
+            ReflectionInfo.FieldOffsetCtor,
+            new object[] { FieldOffset.Value }
+        );
+    }
+}

--- a/src/Ctypes.csproj
+++ b/src/Ctypes.csproj
@@ -4,6 +4,7 @@
     <!--System.Reflection.Emit does not work with netstandard2.0-->
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AssemblyName>Ctypes</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/src/Library.cs
+++ b/src/Library.cs
@@ -29,7 +29,6 @@ public sealed class Library : IDynamicMetaObjectProvider
     {
         string assemblyName = $"Ctypes.PInvoke.{dllName}";
 
-
         // Dotnet Framework cannot call PInvoke methods in a collectable
         // assembly so use Run there.
         _assembly = AssemblyBuilder.DefineDynamicAssembly(
@@ -90,9 +89,7 @@ public sealed class Library : IDynamicMetaObjectProvider
             return null;
         }
 
-        CustomAttributeBuilder marshalAs = new(
-            ReflectionInfo.MarshalAsCtor,
-            new object[] { attr });
+        MarshalAsAttribute marshalAs = new(attr);
 
         PSObject valueObj = PSObject.AsPSObject(value);
         PSNoteProperty marshalAsInfo = new(MARSHAL_AS_NOTE_NAME, marshalAs);

--- a/src/ScriptBlockDelegate.cs
+++ b/src/ScriptBlockDelegate.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using System.Runtime.InteropServices;
+
+namespace Ctypes;
+
+internal sealed class ScriptBlockDelegate
+{
+    private ScriptBlockAst _scriptAst;
+
+    public ScriptBlock Action { get; }
+
+    public ScriptBlockDelegate(ScriptBlock action)
+    {
+        Action = action;
+        _scriptAst = (ScriptBlockAst)action.Ast;
+    }
+
+    public TypeInformation GetReturnType()
+    {
+        return ProcessOutputType(
+            (IEnumerable<AttributeAst>?)_scriptAst.ParamBlock?.Attributes ?? Array.Empty<AttributeAst>());
+    }
+
+    public TypeInformation[] GetParameterTypes()
+    {
+        return _scriptAst.ParamBlock?.Parameters
+            ?.Select(p => ProcessParameterType(p))
+            ?.ToArray() ?? Array.Empty<TypeInformation>();
+    }
+
+    private static TypeInformation ProcessOutputType(IEnumerable<AttributeAst> paramAttributes)
+    {
+        MarshalAsAttribute? marshalAs = null;
+
+        Type? outputType = null;
+        foreach (AttributeBaseAst attr in paramAttributes)
+        {
+            if (attr is not AttributeAst ast)
+            {
+                continue;
+            }
+
+            if (
+                ast.TypeName.GetReflectionType() == typeof(OutputTypeAttribute) &&
+                ast.PositionalArguments.Count == 1 &&
+                ast.PositionalArguments[0] is TypeExpressionAst outputTypeAst
+            )
+            {
+                outputType = outputTypeAst.TypeName.GetReflectionType();
+            }
+            else if (marshalAs == null)
+            {
+                marshalAs = TryParseMarshalAs(ast);
+            }
+        }
+
+        return new("", outputType ?? typeof(void), marshalAs: marshalAs);
+    }
+
+    private static TypeInformation ProcessParameterType(ParameterAst parameter)
+    {
+
+        MarshalAsAttribute? marshalAs = null;
+        bool isIn = false;
+        bool isOut = false;
+
+        Type paramType = paramType = parameter.StaticType;
+        if (paramType == typeof(object) && parameter.Attributes.Count == 0)
+        {
+            // Default to IntPtr if not explicit type was specified.
+            paramType = typeof(IntPtr);
+        }
+        foreach (AttributeBaseAst attr in parameter.Attributes)
+        {
+            if (attr is not AttributeAst ast)
+            {
+                continue;
+            }
+
+            isIn = isIn || ast.TypeName.GetReflectionType() == typeof(InAttribute);
+            isOut = isOut || ast.TypeName.GetReflectionType() == typeof(OutAttribute);
+            if (marshalAs == null)
+            {
+                marshalAs = TryParseMarshalAs(ast);
+            }
+        }
+
+        return new(parameter.Name.VariablePath.UserPath, paramType, marshalAs: marshalAs,
+            isIn: isIn, isOut: isOut);
+    }
+
+    private static MarshalAsAttribute? TryParseMarshalAs(AttributeAst ast)
+    {
+        try
+        {
+            return AstParser.ParseMarshalAs(ast);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Added support for calling C functions that accept a delegate/callback by using a PowerShell scriptblock. The scriptblock is parsed at runtime to dynamically define the delegate needed and PowerShell/dotnet will do the rest of the work to invoke it when needed.