### PR TITLE
Add MarshalAs raw attr support and expand errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.3.0 - TBD
 
++ Added `MarshalAs` support for specifying the full `MarshalAsAttribute` value for more complex scenarios
++ Added `LastErrorMessage`, `ThrowLastErrorException()` and `GetLastErrorRecord()` as a convenient ways for getting the last native error details
+
 ## v0.2.1 - 2024-11-11
 
 + Fix specifying dll through full path rather than just the filename

--- a/docs/en-US/about_CtypesInterface.md
+++ b/docs/en-US/about_CtypesInterface.md
@@ -213,6 +213,12 @@ The character set will use `[System.Runtime.InteropServices.CharSet]::Unicode`, 
 On a failure it retrieves the error code through the `LastError` property on the object.
 Do not use `[System.Runtime.InteropServices.Marshal]::GetLastWin32Error()` as that value could have been mutated by the PowerShell engine between statements. The `LastError` property is retrieved using that code but at a stage where PowerShell may not have overidden it.
 
+It is also possible to use the following properties/methods to get the last error information:
+
++ `LastErrorMessage` - A property that returns the last error message
++ `GetLastErrorRecord(string errorId)` - Returns a PowerShell `ErrorRecord` which can be written to the pipeline with the `System.ComponentModel.Win32Exception` exception attached
++ `ThrowLastErrorException()` - Throws the `System.ComponentModel.Win32Exception` exception for the `LastError` value
+
 # MarshalAs Attributes
 Another attribute used in PInvoke definitions is the ability to mark specific arguments with a [MarshalAsAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshalasattribute?view=net-7.0).
 This attribute can be used to control how strings are marshaled as, or define array marshaling behaviour.
@@ -256,6 +262,21 @@ $lib.SetLastError().Returns([IntPtr]).CreateFileW(
     [System.IO.FileMode]::Create,
     0,
     [IntPtr]::Zero)
+```
+
+For more complex `MarshalAs` examples that are not covered by the `UnamangedType` annotation, the whole attribute value can be specified instead:
+
+```powershell
+$policies = [Guid[]]@(...)
+$subcategoryMarshaling = [System.Runtime.InteropServices.MarshalAsAttribute]::new(
+    [System.Runtime.InteropServices.UnmanagedType]::LPArray)
+$subcategoryMarshaling.SizeParamIndex = 1
+
+$auditPolicy = [IntPtr]::Zero
+$lib.SetLastError().Returns([bool]).AuditQuerySystemPolicy(
+    $lib.MarshalAs($policies, $subcategoryMarshaling),
+    $policies.Count,
+    [ref]$auditPolicy)
 ```
 
 # Delegate Functions

--- a/src/Ctypes/Library.cs
+++ b/src/Ctypes/Library.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Dynamic;
 using System.IO;
 using System.Linq.Expressions;
@@ -23,6 +24,7 @@ public sealed class Library : IDynamicMetaObjectProvider
     internal bool? _setLastError = null;
 
     public int LastError { get; internal set; } = 0;
+    public string LastErrorMessage => new Win32Exception(LastError).Message;
 
     public string DllName { get; }
 
@@ -85,18 +87,41 @@ public sealed class Library : IDynamicMetaObjectProvider
 
     public PSObject? MarshalAs(object? value, UnmanagedType attr)
     {
+        MarshalAsAttribute marshalAs = new(attr);
+        return MarshalAs(value, marshalAs);
+    }
+
+    public PSObject? MarshalAs(object? value, MarshalAsAttribute attr)
+    {
         if (value == null)
         {
             return null;
         }
 
-        MarshalAsAttribute marshalAs = new(attr);
-
         PSObject valueObj = PSObject.AsPSObject(value);
-        PSNoteProperty marshalAsInfo = new(MARSHAL_AS_NOTE_NAME, marshalAs);
+        PSNoteProperty marshalAsInfo = new(MARSHAL_AS_NOTE_NAME, attr);
         valueObj.Properties.Add(marshalAsInfo);
 
         return valueObj;
+    }
+
+    public ErrorRecord GetLastErrorRecord(
+        string errorId)
+    {
+        ErrorRecord err = new(
+            new Win32Exception(LastError),
+            errorId,
+            ErrorCategory.InvalidResult,
+            LastError);
+        err.ErrorDetails = new(string.Format(
+            "{0} (0x{1:X8})", err.Exception.Message, LastError));
+
+        return err;
+    }
+
+    public void ThrowLastErrorException()
+    {
+        throw new Win32Exception(LastError);
     }
 
     public DynamicMetaObject GetMetaObject(Expression parameter)

--- a/tests/New-CtypesLib.Tests.ps1
+++ b/tests/New-CtypesLib.Tests.ps1
@@ -422,7 +422,8 @@ Describe "New-CtypesLib" {
         It "Defines API with MarshalAs parameter with ordered dict" {
             $lib = New-CtypesLib MyLib
             $lib.MyFunc = [Ordered]@{
-                MyArg1 = $lib.MarshalAs([string], 'LPWStr')
+                MyArg1 = $lib.MarshalAs([string], [System.Runtime.InteropServices.MarshalAsAttribute]::new(
+                        [System.Runtime.InteropServices.UnmanagedType]::LPWStr))
             }
 
             $actual = $lib.MyFunc
@@ -973,6 +974,37 @@ Describe "New-CtypesLib" {
             }
         }
 
+        It "Throws last error code on failure" {
+            $lib = New-CtypesLib Kernel32.dll
+
+            $procHandle = $lib.Returns([IntPtr]).SetLastError().OpenProcess(
+                0x400, # PROCESS_QUERY_INFORMATION
+                $false,
+                1)
+            $procHandle | Should -Be ([IntPtr]::Zero)
+
+            {
+                $lib.ThrowLastErrorException()
+            } | Should -Throw "*$($lib.LastErrorMessage)*"
+        }
+        It "Creates ErrorRecord on failure" {
+            $lib = New-CtypesLib Kernel32.dll
+
+            $procHandle = $lib.Returns([IntPtr]).SetLastError().OpenProcess(
+                0x400, # PROCESS_QUERY_INFORMATION
+                $false,
+                1)
+            $procHandle | Should -Be ([IntPtr]::Zero)
+
+            $actual = $lib.GetLastErrorRecord("MyErrorId")
+            $actual | Should -BeOfType ([System.Management.Automation.ErrorRecord])
+            $actual.Exception | Should -BeOfType ([System.ComponentModel.Win32Exception])
+            $actual.FullyQualifiedErrorId | Should -Be "MyErrorId"
+            $actual.CategoryInfo.Category | Should -Be InvalidResult
+            $actual.ErrorDetails.Message | Should -Be "$($lib.LastErrorMessage) (0x00000057)"
+            $actual.TargetObject | Should -Be 87
+        }
+
         It "Uses complex argument" {
             ctypes_struct SECURITY_ATTRIBUTES {
                 [int]$Length
@@ -1248,6 +1280,41 @@ Describe "New-CtypesLib" {
             )
             $fd | Should -Be -1
             $lib.LastError | Should -Be 2
+        }
+
+        It "Throws last error code on failure" {
+            $lib = New-CtypesLib libc
+
+            $filePath = "/tmp/missing folder/pwsh-ctypes-$([Guid]::NewGuid())"
+            $fd = $lib.SetLastError().open(
+                $lib.MarshalAs($filePath, 'LPUTF8Str'),
+                0x42,
+                448  # S_IRWXU
+            )
+            $fd | Should -Be -1
+            {
+                $lib.ThrowLastErrorException()
+            } | Should -Throw
+        }
+
+        It "Creates ErrorRecord on failure" {
+            $lib = New-CtypesLib libc
+
+            $filePath = "/tmp/missing folder/pwsh-ctypes-$([Guid]::NewGuid())"
+            $fd = $lib.SetLastError().open(
+                $lib.MarshalAs($filePath, 'LPUTF8Str'),
+                0x42,
+                448  # S_IRWXU
+            )
+            $fd | Should -Be -1
+
+            $actual = $lib.GetLastErrorRecord("MyErrorId")
+            $actual | Should -BeOfType ([System.Management.Automation.ErrorRecord])
+            $actual.Exception | Should -BeOfType ([System.ComponentModel.Win32Exception])
+            $actual.FullyQualifiedErrorId | Should -Be "MyErrorId"
+            $actual.CategoryInfo.Category | Should -Be InvalidResult
+            $actual.ErrorDetails.Message | Should -Be "$($lib.LastErrorMessage) (0x00000002)"
+            $actual.TargetObject | Should -Be 2
         }
     }
 }


### PR DESCRIPTION
Adds the ability to specify a custom MarshalAsAttribute for a value rather than just the UnmanagedType value. Also adds a few helpers methods for getting and generating Exceptions/ErrorRecords for last error failures.