### PR TITLE
Raise minimum pwsh 7 version to 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,23 +60,17 @@ jobs:
         - name: PS_5.1_x64_Windows
           psversion: '5.1'
           os: windows-latest
-        - name: PS_7.2_x64_Windows
-          psversion: '7.2.0'
-          os: windows-latest
-        - name: PS_7.2_x64_Linux
-          psversion: '7.2.0'
-          os: ubuntu-latest
-        - name: PS_7.3_x64_Windows
-          psversion: '7.3.0'
-          os: windows-latest
-        - name: PS_7.3_x64_Linux
-          psversion: '7.3.0'
-          os: ubuntu-latest
         - name: PS_7.4_x64_Windows
           psversion: '7.4.0'
           os: windows-latest
         - name: PS_7.4_x64_Linux
           psversion: '7.4.0'
+          os: ubuntu-latest
+        - name: PS_7.5_x64_Windows
+          psversion: '7.5.0'
+          os: windows-latest
+        - name: PS_7.5_x64_Linux
+          psversion: '7.5.0'
           os: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.3.0 - TBD
 
++ Set minimum PowerShell 7 version as 7.4
 + Added `MarshalAs` support for specifying the full `MarshalAsAttribute` value for more complex scenarios
 + Added `LastErrorMessage`, `ThrowLastErrorException()` and `GetLastErrorRecord()` as a convenient ways for getting the last native error details
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ _Note: This can't return a string directly as dotnet will try and free the memor
 
 These cmdlets have the following requirements
 
-* PowerShell v5.1 or newer
+* PowerShell v5.1, or 7.4+
 
 ## Installing
 
@@ -177,9 +177,11 @@ You can install this module by running;
 
 ```powershell
 # Install for only the current user
+Install-PSResource -Name Ctypes -Scope CurrentUser
 Install-Module -Name Ctypes -Scope CurrentUser
 
 # Install for all users
+Install-PSResource -Name Ctypes -Scope AllUsers
 Install-Module -Name Ctypes -Scope AllUsers
 ```
 

--- a/module/Ctypes.psd1
+++ b/module/Ctypes.psd1
@@ -12,7 +12,7 @@
 
     # Script module or binary module file associated with this manifest.
     RootModule = if ($PSEdition -eq 'Core') {
-        'bin/net6.0/Ctypes.dll'
+        'bin/net8.0/Ctypes.dll'
     }
     else {
         'bin/net472/Ctypes.dll'

--- a/src/Ctypes/Ctypes.csproj
+++ b/src/Ctypes/Ctypes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--System.Reflection.Emit does not work with netstandard2.0-->
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
@@ -22,12 +22,12 @@
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-555c-2p6r-68mm" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0" PrivateAssets="all" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="System.Management.Automation" Version="7.4.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/src/Ctypes/Library.cs
+++ b/src/Ctypes/Library.cs
@@ -36,7 +36,7 @@ public sealed class Library : IDynamicMetaObjectProvider
         // assembly so use Run there.
         _assembly = AssemblyBuilder.DefineDynamicAssembly(
             new(assemblyName),
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             AssemblyBuilderAccess.RunAndCollect);
 #else
             AssemblyBuilderAccess.Run);

--- a/src/Ctypes/NewCtypesStruct.cs
+++ b/src/Ctypes/NewCtypesStruct.cs
@@ -126,7 +126,7 @@ public sealed class CtypesStructCommand : PSCmdlet
             }
 
             Type fieldType = info.Type;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             // Enums in pwsh are defined with RunAndCollect and cannot be used
             // in an assembly that is also not collectible. Copy across the
             // enum to the current assembly.
@@ -241,7 +241,7 @@ public sealed class CtypesStructCommand : PSCmdlet
         );
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static Type CopyEnumToAssembly(Type enumToCopy, ModuleBuilder mb)
     {
         Type underlyingType = Enum.GetUnderlyingType(enumToCopy);


### PR DESCRIPTION
Raises the minimum PowerShell 7 version to 7.4 to reflect the currently supported PowerShell versions.